### PR TITLE
Added tests and support for new option: 'requireTemplateContent'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Use
 var dust = require('dustjs-linkedin');
 require('dust-makara-helpers').registerWith(dust, {
     enableMetadata: true,
-    autoloadTemplateContent: false
+    autoloadTemplateContent: false,
+    requireTemplateContent: false
 });
 ```
 
@@ -25,5 +26,7 @@ Options
 
 * `enableMetadata`: defaults to `false`. Turns on support for `<edit>` metadata tags in [dust-message-helper] to support in-place content editing.
 * `autoloadTemplateContent`: defaults to `true`. Allows you to disable automatic loading of content per template, allowing you to have a completely disjoint mapping between templates and content bundles, rather than a 1:1 mapping of template name to content bundle filename.
+* `requireTemplateContent`: defaults to `true`. Allows you to disable the requirement
+that each template have its corresponding `.proerties` file by name.
 
 [dust-message-helper]: https://github.com/krakenjs/dust-message-helper

--- a/test/fixtures/templates/without-content.dust
+++ b/test/fixtures/templates/without-content.dust
@@ -1,0 +1,2 @@
+{! I have no properties file !}
+{> "simple"/}

--- a/test/optionalcontent.js
+++ b/test/optionalcontent.js
@@ -1,0 +1,51 @@
+"use strict";
+var makarahelpers = require('../');
+var test = require('tap').test;
+var path = require('path');
+var fs = require('fs');
+var freshy = require('freshy').freshy;
+var makeViewClass = require('engine-munger');
+var View = makeViewClass({
+    properties: {
+        root: path.resolve(__dirname, 'fixtures'),
+        i18n: {
+            fallback: 'en-US',
+            formatPath: function (locale) {
+                return path.join(locale.langtag.region, locale.langtag.language.language);
+            }
+        }
+    }
+});
+
+function render(dust, name, context, cb) {
+    var ctx = dust.context(context, { view: new View(name + '.dust', { engines: { ".dust": function() {} } }) });
+    ctx.templateName = name;
+    dust.render(name, ctx, cb);
+}
+
+function newDust() {
+    var dust = freshy('dustjs-linkedin');
+
+    dust.debugLevel = 'WARN';
+
+    dust.onLoad = function(name, options, cb) {
+        fs.readFile(path.resolve(__dirname, 'fixtures/templates', name + '.dust'), 'utf-8', cb);
+    };
+
+    return dust;
+}
+
+test('Make sure optional bundle content can be enabled', function (t) {
+    var dust = newDust();
+
+    makarahelpers.registerWith(dust, {
+        autoloadTemplateContent: true,
+        requireTemplateContent: false
+    });
+
+    render(dust, 'without-content', { locale: { country: 'US', language: 'en' } }, function (err, out) {
+        t.error(err);
+        t.equal(out, 'Hello');
+        t.end();
+    });
+});


### PR DESCRIPTION
- Set to false allows omitting .properties files for templates that don't require i18n
