### PR TITLE
add new options useLocaleObject and localeContexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This module requires the full build of dust, with the compiler, since the `@mess
 Use
 ----
 
-```
+```js
 var dust = require('dustjs-linkedin');
 require('dust-makara-helpers').registerWith(dust, {
     enableMetadata: true,

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Use
 var dust = require('dustjs-linkedin');
 require('dust-makara-helpers').registerWith(dust, {
     enableMetadata: true,
-    autoloadTemplateContent: false
+    autoloadTemplateContent: false,
+    useLocaleObject: true,
+    localeContexts: ["makaraLocale"]
 });
 ```
 
@@ -25,5 +27,7 @@ Options
 
 * `enableMetadata`: defaults to `false`. Turns on support for `<edit>` metadata tags in [dust-message-helper] to support in-place content editing.
 * `autoloadTemplateContent`: defaults to `true`. Allows you to disable automatic loading of content per template, allowing you to have a completely disjoint mapping between templates and content bundles, rather than a 1:1 mapping of template name to content bundle filename.
+* `useLocaleObject`: defaults to `false`. Setting to true prevents the conversion of locale to a string. This is a way to allow you to use non-standard locales but in a bcp47 format.
+* `localeContexts`: Array of Strings. defaults to an array of expected context keys for the locale object. You can override that array if you have a different key, or set of keys, where you want to search for the locales.
 
 [dust-message-helper]: https://github.com/krakenjs/dust-message-helper

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var localeContexts = ['contentLocale', 'contentLocality', 'locale', 'locality']
 var localeTransform;
 module.exports = function(dust, options) {
     options = options || {};
-    localeTransform = (options.useLocaleObject) ? localeNoTransform : localeToString;
+    localeTransform = (options.useLocaleObject !== undefined && options.useLocaleObject === false) ? localeNoTransform : localeToString;
     localeContexts = options.localeContexts || localeContexts;
     // We bind the loader for the useContent helper here to the express view
     // class's lookup method. It must be the express 5 style one, asynchronous,

--- a/index.js
+++ b/index.js
@@ -6,12 +6,11 @@ var debug = require('debuglog')('dust-makara-helpers');
 var fs = require('fs');
 var aproba = require('aproba');
 var bcp47s = require('bcp47-stringify');
-
 var common = require('./common');
-
+var localeOp;
 module.exports = function(dust, options) {
     options = options || {};
-
+    localeOp = (options.useLocaleObject) ? localeNoop : stringLocale;
     // We bind the loader for the useContent helper here to the express view
     // class's lookup method. It must be the express 5 style one, asynchronous,
     // and for internationalized lookups to work, it must be the backport and
@@ -76,10 +75,13 @@ function stringLocale(locale) {
     }
 }
 
+function localeNoop(locale) {
+    return locale;   
+}
 function localeFromContext(ctx) {
     // Handle all the backward compatibility names (*Locality) and the new
     // ones, too.
-    return stringLocale(ctx.get('contentLocale') || ctx.get('contentLocality') ||
+    return localeOp(ctx.get('contentLocale') || ctx.get('contentLocality') ||
         ctx.get('locale') || ctx.get('locality') || {});
 }
 

--- a/index.js
+++ b/index.js
@@ -7,10 +7,12 @@ var fs = require('fs');
 var aproba = require('aproba');
 var bcp47s = require('bcp47-stringify');
 var common = require('./common');
-var localeOp;
+var localeContexts = ['contentLocale', 'contentLocality', 'locale', 'locality']
+var localeTransform;
 module.exports = function(dust, options) {
     options = options || {};
-    localeOp = (options.useLocaleObject) ? localeNoop : stringLocale;
+    localeTransform = (options.useLocaleObject) ? localeNoTransform : localeToString;
+    localeContexts = options.localeContexts || localeContexts;
     // We bind the loader for the useContent helper here to the express view
     // class's lookup method. It must be the express 5 style one, asynchronous,
     // and for internationalized lookups to work, it must be the backport and
@@ -62,7 +64,7 @@ function makeErr(ctx, bundle) {
     return new VError(str, ctx.templateName, bundle);
 }
 
-function stringLocale(locale) {
+function localeToString(locale) {
     debug("normalizing locale %j", locale);
     if (!locale) {
         return undefined;
@@ -75,14 +77,17 @@ function stringLocale(locale) {
     }
 }
 
-function localeNoop(locale) {
+function localeNoTransform(locale) {
     return locale;   
 }
 function localeFromContext(ctx) {
-    // Handle all the backward compatibility names (*Locality) and the new
-    // ones, too.
-    return localeOp(ctx.get('contentLocale') || ctx.get('contentLocality') ||
-        ctx.get('locale') || ctx.get('locality') || {});
+    var locale;
+    localeContexts.some(function (key) {
+        locale = ctx.get(key);
+        debug("performing lookup for locale in context key '%s'. Found %j", key, locale);
+        return locale !== undefined;
+    });
+    return localeTransform(locale || {});
 }
 
 module.exports.registerWith = module.exports;


### PR DESCRIPTION
`useLocaleObject` configurable option to leave locale object alone. resolves #13
`localeContexts` array which can override internal array of expected locale object keys